### PR TITLE
Added cooldown as a configurable value

### DIFF
--- a/GamblersMod/Constants/GambleConstants.cs
+++ b/GamblersMod/Constants/GambleConstants.cs
@@ -3,9 +3,13 @@
     public class GambleConstants
     {
         // Section keys
+        public readonly static string GAMBLING_GENERAL_SECTION_KEY= "General Machine Settings";
         public readonly static string GAMBLING_CHANCE_SECTION_KEY = "Gambling Chances";
         public readonly static string GAMBLING_MULTIPLIERS_SECTION_KEY = "Gambling Multipliers";
         public readonly static string GAMBLING_AUDIO_SECTION_KEY = "Audio";
+
+        // General Subsection keys
+        public readonly static string CONFIG_MAXCOOLDOWN = "gamblingMachineMaxCooldown";
 
         // Chance subsection keys
         public readonly static string CONFIG_JACKPOT_CHANCE_KEY = "JackpotChance";

--- a/GamblersMod/GamblingMachine/GamblingMachine.cs
+++ b/GamblersMod/GamblingMachine/GamblingMachine.cs
@@ -9,7 +9,7 @@ namespace GamblersMod.Patches
     internal class GamblingMachine : NetworkBehaviour
     {
         // Cooldown
-        int gamblingMachineMaxCooldown = 4;
+        int gamblingMachineMaxCooldown;
         public int gamblingMachineCurrentCooldown = 0;
 
         // Multipliers for winning or losing
@@ -46,6 +46,9 @@ namespace GamblersMod.Patches
         {
             Plugin.mls.LogInfo("GamblingMachine has Awoken");
 
+            //General
+            gamblingMachineMaxCooldown = Plugin.CurrentUserConfig.configMaxCooldown;
+
             // Multipliers
             jackpotMultiplier = Plugin.CurrentUserConfig.configJackpotMultiplier;
             tripleMultiplier = Plugin.CurrentUserConfig.configTripleMultiplier;
@@ -63,6 +66,8 @@ namespace GamblersMod.Patches
             // Audio 
             isMusicEnabled = Plugin.CurrentUserConfig.configGamblingMusicEnabled;
             musicVolume = Plugin.CurrentUserConfig.configGamblingMusicVolume;
+
+            Plugin.mls.LogInfo($"GamblingMachine: gamblingMachineMaxCooldown loaded from config: {gamblingMachineMaxCooldown}");
 
             Plugin.mls.LogInfo($"GamblingMachine: jackpotMultiplier loaded from config: {jackpotMultiplier}");
             Plugin.mls.LogInfo($"GamblingMachine: tripleMultiplier loaded from config: {tripleMultiplier}");

--- a/GamblersMod/config/GambleConfigNetworkHelper.cs
+++ b/GamblersMod/config/GambleConfigNetworkHelper.cs
@@ -81,6 +81,8 @@ namespace GamblersMod.config
 
             var pluginLogger = Plugin.mls;
 
+            pluginLogger.LogInfo($"Cooldown value from config: {Plugin.CurrentUserConfig.configMaxCooldown}");
+
             pluginLogger.LogInfo($"Jackpot chance value from config: {Plugin.CurrentUserConfig.configJackpotChance}");
             pluginLogger.LogInfo($"Triple chance value from config: {Plugin.CurrentUserConfig.configTripleChance}");
             pluginLogger.LogInfo($"Double chance value from config: {Plugin.CurrentUserConfig.configDoubleChance}");

--- a/GamblersMod/config/GambleConfigSettingsSerializable.cs
+++ b/GamblersMod/config/GambleConfigSettingsSerializable.cs
@@ -7,6 +7,9 @@ namespace GamblersMod.config
     [Serializable]
     public class GambleConfigSettingsSerializable
     {
+        //General
+        public int configMaxCooldown;
+
         // Gambling chances
         public int configJackpotChance;
         public int configTripleChance;
@@ -27,6 +30,9 @@ namespace GamblersMod.config
 
         public GambleConfigSettingsSerializable(ConfigFile configFile)
         {
+            // General
+            configFile.Bind(GAMBLING_GENERAL_SECTION_KEY, CONFIG_MAXCOOLDOWN, 4, "Cooldown of the machine.");
+
             // Chance
             configFile.Bind(GAMBLING_CHANCE_SECTION_KEY, CONFIG_JACKPOT_CHANCE_KEY, 3, "Chance to roll a jackpot. Ex. If set to 3, you have a 3% chance to get a jackpot. Make sure ALL your chance values add up to 100 or else the math won't make sense!");
             configFile.Bind(GAMBLING_CHANCE_SECTION_KEY, CONFIG_TRIPLE_CHANCE_KEY, 11, "Chance to roll a triple. Ex. If set to 11, you have a 11% chance to get a triple. Make sure ALL your chance values add up to 100 or else the math won't make sense!");
@@ -44,6 +50,8 @@ namespace GamblersMod.config
             // Audio
             configFile.Bind(GAMBLING_AUDIO_SECTION_KEY, CONFIG_GAMBLING_MUSIC_ENABLED, true, "Enable gambling machine music (CLIENT SIDE)");
             configFile.Bind(GAMBLING_AUDIO_SECTION_KEY, CONFIG_GAMBLING_MUSIC_VOLUME, 0.35f, "Gambling machine music volume (CLIENT SIDE)");
+
+            configMaxCooldown = GetConfigFileKeyValue<int>(configFile, GAMBLING_GENERAL_SECTION_KEY, CONFIG_MAXCOOLDOWN);
 
             configJackpotChance = GetConfigFileKeyValue<int>(configFile, GAMBLING_CHANCE_SECTION_KEY, CONFIG_JACKPOT_CHANCE_KEY);
             configTripleChance = GetConfigFileKeyValue<int>(configFile, GAMBLING_CHANCE_SECTION_KEY, CONFIG_TRIPLE_CHANCE_KEY);
@@ -66,6 +74,8 @@ namespace GamblersMod.config
         private void LogInitializedConfigsValues()
         {
             var pluginLogger = Plugin.mls;
+            pluginLogger.LogInfo($"Cooldown value from config: {configMaxCooldown}");
+
             pluginLogger.LogInfo($"Jackpot chance value from config: {configJackpotChance}");
             pluginLogger.LogInfo($"Triple chance value from config: {configTripleChance}");
             pluginLogger.LogInfo($"Double chance value from config: {configDoubleChance}");

--- a/ThunderStore/GamblersMod/README.md
+++ b/ThunderStore/GamblersMod/README.md
@@ -35,6 +35,8 @@ While holding a scrap, walk up to the machine and press "E" (your interaction ke
 
 ## Configurable Fields
 
+- General Settings
+  - Cooldown Time
 - Gambling Chance fields (make sure these fields add up to 100; if not it'll still work, but math will be inaccurate)
   - Jackpot Chance
   - Triple Chance


### PR DESCRIPTION
I went through and added the cooldown time to the configurable variables, same as a lot of the other variables are. I've tested with myself in a lobby and it works, compiles without error, but haven't tested with another person, or multiple people. I think it will work fine though. I also haven't tested negative or non-whole numbers - not sure if that is necessary to filter out being I don't think I see any protection on the others.

Quite a few friends and I were playing with this mod and it is great! Really saved us a few times when we were short on quota (and burned us a few times with we got greedy!). However, with 5+ people and a few dozen pieces of loot we want to gamble, we end up being at the company building for quite a long time with the long cooldown. We could cut this down dramatically with a cooldown of say 1 second. Or, if we want to play more challenging and discourage gambling, set it to something like 10 seconds.

One of the only other quirky things I can think of is the 4 second drumroll clip is now either played on top of itself and the result clip is played under it if the cooldown is set lower, or there is a delay between the end of the drumroll clip and the result clip if its set higher. The only thing I can think of to fix this is to split the drumroll clip into 3 audio segments, play the first segment on interaction, loop the middle segment as long as needed, and play the 'tss right before the result clip. I'm thinking of looking into this, but for now this adds the basic functionality.

Only other thing is I don't know how a lower cooldown time will affect server / client sync with latency and spamming the machine. If it does, I think having it editable with an understanding that putting low cooldowns may affect stability with spamming it is up to the host possibly. Though I think I saw some logic in there that denies any subsequent requests after one request has been accepted by the server.

Thanks for the great mod and hope this helps!